### PR TITLE
Store more beautifier options to config

### DIFF
--- a/NinjaKit.safariextension/js/options.js
+++ b/NinjaKit.safariextension/js/options.js
@@ -109,6 +109,14 @@ function init(){
     FontList();
   }
 
+  var currentTabSize = +Config.options.tabSize || 1;
+  var tabSize = document.getElementById('tabsize');
+  tabSize.value = currentTabSize;
+  tabSize.onclick = function() {
+    Config.options.tabSize = tabSize.value;
+    localStorage.Config = JSON.stringify(Config);
+  };
+
   var add = document.getElementById('add_script');
   var add_script = function(){
     var styl = {

--- a/NinjaKit.safariextension/js/options.js
+++ b/NinjaKit.safariextension/js/options.js
@@ -109,25 +109,26 @@ function init(){
     FontList();
   }
 
-  var currentTabSize = +Config.options.tabSize || 1;
-  var tabSize = document.getElementById('tabsize');
-  tabSize.value = currentTabSize;
-  tabSize.onclick = function() {
-    Config.options.tabSize = tabSize.value;
-    localStorage.Config = JSON.stringify(Config);
-  };
-
+  initializeOption('tabsize', 'tabSize', 1);
   initializeOption('braces-on-own-line', 'bracesOnOwnLine', true);
   initializeOption('preserve-newlines', 'preserveNewlines', true);
   initializeOption('detect-packers', 'detectPackers', false);
   initializeOption('keep-array-indentation', 'keepArrayIndentation', false);
 
   function initializeOption(id, optionKey, defaultValue) {
-    var currentValue = Config.options[optionKey] === undefined ? defaultValue : Config.options[optionKey];
-    var element = document.getElementById(id);
-    element.checked = currentValue ? true : false;
+    var currentValue, key,
+        element = document.getElementById(id);
+    if (element.tagName == "INPUT" && element.type == "checkbox") {
+      currentValue = Config.options[optionKey] === undefined ? defaultValue : Config.options[optionKey];
+      key = "checked";
+      element.checked = currentValue ? true : false;
+    } else {
+      currentValue = +Config.options[optionKey] || defaultValue;
+      key = "value";
+      element.value = currentValue;
+    }
     element.onclick = function() {
-      Config.options[optionKey] = element.checked;
+      Config.options[optionKey] = element[key];
       localStorage.Config = JSON.stringify(Config);
     }
   }

--- a/NinjaKit.safariextension/js/options.js
+++ b/NinjaKit.safariextension/js/options.js
@@ -117,6 +117,14 @@ function init(){
     localStorage.Config = JSON.stringify(Config);
   };
 
+  var currentBracesOnNewLine = Config.options.bracesOnNewLine === undefined ? true : Config.options.bracesOnNewLine;
+  var bracesOnNewLine = document.getElementById('braces-on-own-line');
+  bracesOnNewLine.checked = currentBracesOnNewLine ? true : false;
+  bracesOnNewLine.onclick = function() {
+    Config.options.bracesOnNewLine = bracesOnNewLine.checked;
+    localStorage.Config = JSON.stringify(Config);
+  }
+
   var add = document.getElementById('add_script');
   var add_script = function(){
     var styl = {

--- a/NinjaKit.safariextension/js/options.js
+++ b/NinjaKit.safariextension/js/options.js
@@ -117,12 +117,16 @@ function init(){
     localStorage.Config = JSON.stringify(Config);
   };
 
-  var currentBracesOnNewLine = Config.options.bracesOnNewLine === undefined ? true : Config.options.bracesOnNewLine;
-  var bracesOnNewLine = document.getElementById('braces-on-own-line');
-  bracesOnNewLine.checked = currentBracesOnNewLine ? true : false;
-  bracesOnNewLine.onclick = function() {
-    Config.options.bracesOnNewLine = bracesOnNewLine.checked;
-    localStorage.Config = JSON.stringify(Config);
+  initializeOption('braces-on-own-line', 'bracesOnOwnLine', true);
+
+  function initializeOption(id, optionKey, defaultValue) {
+    var currentValue = Config.options[optionKey] === undefined ? defaultValue : Config.options[optionKey];
+    var element = document.getElementById(id);
+    element.checked = currentValue ? true : false;
+    element.onclick = function() {
+      Config.options[optionKey] = element.checked;
+      localStorage.Config = JSON.stringify(Config);
+    }
   }
 
   var add = document.getElementById('add_script');

--- a/NinjaKit.safariextension/js/options.js
+++ b/NinjaKit.safariextension/js/options.js
@@ -118,6 +118,9 @@ function init(){
   };
 
   initializeOption('braces-on-own-line', 'bracesOnOwnLine', true);
+  initializeOption('preserve-newlines', 'preserveNewlines', true);
+  initializeOption('detect-packers', 'detectPackers', false);
+  initializeOption('keep-array-indentation', 'keepArrayIndentation', false);
 
   function initializeOption(id, optionKey, defaultValue) {
     var currentValue = Config.options[optionKey] === undefined ? defaultValue : Config.options[optionKey];

--- a/NinjaKit.safariextension/options.html
+++ b/NinjaKit.safariextension/options.html
@@ -37,8 +37,8 @@
             <option value="8">indent with 8 spaces</option>
           </select>
         </li>
-        <li><input type="checkbox" id="braces-on-own-line" checked="checked"><label for="braces-on-own-line"> Braces on own line</label></li>
-        <li><input type="checkbox" id="preserve-newlines" checked="checked"><label for="preserve-newlines"> Preserve empty lines?</label></li>
+        <li><input type="checkbox" id="braces-on-own-line"><label for="braces-on-own-line"> Braces on own line</label></li>
+        <li><input type="checkbox" id="preserve-newlines"><label for="preserve-newlines"> Preserve empty lines?</label></li>
         <li><input type="checkbox" id="detect-packers"><label for="detect-packers"> Detect packers?</label></li>
         <li><input type="checkbox" id="keep-array-indentation"><label for="keep-array-indentation"> Keep array indentation?</label></li>
         <li> Font size: <span id="currentFontSize">12</span><br> 8<input type="range" id="fontSize" value="12" step="1" min="8" max="40">40</li>

--- a/NinjaKit.safariextension/options.html
+++ b/NinjaKit.safariextension/options.html
@@ -30,7 +30,7 @@
       <ul>
         <li>
           <select name="tabsize" id="tabsize">
-            <option value="1" selected="selected">indent with a tab character</option>
+            <option value="1">indent with a tab character</option>
             <option value="2">indent with 2 spaces</option>
             <option value="3">indent with 3 spaces</option>
             <option value="4">indent with 4 spaces</option>


### PR DESCRIPTION
Hi, I like your work! It's the only extension working with current Safari without having to install some special other plugins...

I did some additions to save all the options to the config.
Go through the commits - I also refactored my code, maybe easier to understand step by step.

Initially I wanted to take a look at how to implement saving the selected font and size to config at all, because it doesn't work in my installed version. After I forked, I realized, that code for it already exists and fortunately works here. Don't know the differences between the officially installed version and the source, but I can also live with my fork :-) However, we have to check.
However, after I saw that the other options were missing, I added them.

Greetings from Germany
KSi
